### PR TITLE
Stop caching passphase in cookies

### DIFF
--- a/src/ui/entry.ts
+++ b/src/ui/entry.ts
@@ -89,17 +89,12 @@ function hasMatchedEntry(currentHost: string, entries: OTPEntry[]) {
 async function getCachedPassphrase() {
   return new Promise(
       (resolve: (value: string) => void, reject: (reason: Error) => void) => {
-        const cookie = document.cookie;
-        const cookieMatch =
-            cookie ? document.cookie.match(/passphrase=([^;]*)/) : null;
-        const cachedPassphrase =
-            cookieMatch && cookieMatch.length > 1 ? cookieMatch[1] : null;
         const cachedPassphraseLocalStorage = localStorage.encodedPhrase ?
             CryptoJS.AES.decrypt(localStorage.encodedPhrase, '')
                 .toString(CryptoJS.enc.Utf8) :
             '';
-        if (cachedPassphrase || cachedPassphraseLocalStorage) {
-          return resolve(cachedPassphrase || cachedPassphraseLocalStorage);
+        if (cachedPassphraseLocalStorage) {
+          return resolve(cachedPassphraseLocalStorage);
         }
 
         chrome.runtime.sendMessage(

--- a/src/ui/passphrase.ts
+++ b/src/ui/passphrase.ts
@@ -3,7 +3,6 @@
 /// <reference path="./ui.ts" />
 
 function cachePassword(password: string) {
-  document.cookie = 'passphrase=' + password;
   chrome.runtime.sendMessage({action: 'cachePassphrase', value: password});
 }
 


### PR DESCRIPTION
Storing in cookies is bad and makes removing localStorage password storage pointless. I don't think there is a point anyway as long as its stored here:
https://github.com/Authenticator-Extension/Authenticator/blob/869ad1bd7a554b44e191e8763a48c94cb522b01d/src/background.ts#L17-L20