### PR TITLE
ask for local file access permission

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -52,7 +52,8 @@
     "permissions": [
         "activeTab",
         "storage",
-        "identity"
+        "identity",
+        "file://*/*"
     ],
     "optional_permissions": [
         "clipboardWrite",


### PR DESCRIPTION
If the user opens a QR image from local file, the extension cannot scan it because we had removed content script permission.

`file://*/*` permission is disabled by default event if we request it in manifest, and the user needs enable it manually (https://stackoverflow.com/a/19493206/2956469). So this change doesn't expand permission scope.

This change adds local file access section in Chrome extension dashboard:

![snipaste20180727_162242](https://user-images.githubusercontent.com/1621293/43310147-5eddb7fe-91b9-11e8-849c-b63e2d194ba8.png)
