### PR TITLE
use mozAnon when syncing time with google

### DIFF
--- a/src/ui/menu.ts
+++ b/src/ui/menu.ts
@@ -11,7 +11,8 @@ async function syncTimeWithGoogle() {
   return new Promise(
       (resolve: (value: string) => void, reject: (reason: Error) => void) => {
         try {
-          const xhr = new XMLHttpRequest();
+          // @ts-ignore
+          const xhr = new XMLHttpRequest({'mozAnon': true});
           xhr.open('HEAD', 'https://www.google.com/generate_204');
           const xhrAbort = setTimeout(() => {
             xhr.abort();


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/mozAnon

Doesn't cause issues in Chrome.