### PR TITLE
QR scan encryption fix

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -410,6 +410,10 @@ function setAutolock() {
     document.cookie = `passphrase="${getCachedPassphrase()}${getCookieExpiry()}"`;
     autolockTimeout = setTimeout(() => {
       cachedPassphrase = "";
+      const id = contentTab.id;
+      if (id) {
+        chrome.tabs.sendMessage(id, { action: "stopCapture" });
+      }
     }, Number(localStorage.autolock) * 60000);
   }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -204,6 +204,13 @@ async function getTotp(text: string) {
         if (period) {
           entryData[hash].period = period;
         }
+        if (
+          (await EntryStorage.hasEncryptedEntry()) !==
+          encryption.getEncryptionStatus()
+        ) {
+          chrome.tabs.sendMessage(id, { action: "errorenc" });
+          return;
+        }
         await EntryStorage.import(encryption, entryData);
         chrome.tabs.sendMessage(id, { action: "added", account });
       }

--- a/src/content.ts
+++ b/src/content.ts
@@ -14,6 +14,9 @@ if (!document.getElementById("__ga_grayLayout__")) {
       case "errorqr":
         alert(chrome.i18n.getMessage("errorqr"));
         break;
+      case "errorenc":
+        alert(chrome.i18n.getMessage("phrase_incorrect"));
+        break;
       case "added":
         alert(message.account + chrome.i18n.getMessage("added"));
         break;

--- a/src/content.ts
+++ b/src/content.ts
@@ -23,6 +23,17 @@ if (!document.getElementById("__ga_grayLayout__")) {
       case "pastecode":
         pasteCode(message.code);
         break;
+      case "stopCapture":
+        const captureBox = document.getElementById("__ga_captureBox__");
+        if (captureBox) {
+          captureBox.style.display = "none";
+        }
+
+        const grayLayout = document.getElementById("__ga_grayLayout__");
+        if (grayLayout) {
+          grayLayout.style.display = "none";
+        }
+        break;
       default:
         // invalid command, ignore it
         break;


### PR DESCRIPTION
Adding QR code when encryption is empty will add unencrypted data to storage. This can happen if scanning a QR code after autolock triggers.