### PR TITLE
Allow reset if password is lost

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -107,6 +107,16 @@
         "message": "Are you sure you want to delete this account? This action cannot be undone.",
         "description": "Remove entry confirmation"
     },
+    "confirm_delete_all": {
+        "message": "I understand that all of my data will be irrecoverably deleted.",
+        "description": "Message that user is required to acknowledge before clearing all data."
+    },
+    "delete_all": {
+        "message": "Reset Authenticator"
+    },
+    "delete_all_warning": {
+        "message": "This will delete all of your data and completely reset Authenticator. You will not be able to recover any deleted data! You should consider saving a backup before resetting Authenticator."
+    },
     "security_warning": {
         "message": "This password will be used to encrypt your accounts. No one can help you if you forget the password.",
         "description": "Passphrase Warning."

--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -24,6 +24,10 @@
             "description": "Scan a QR code"
         }
     },
+    "options_ui": {
+        "page": "view/options.html",
+        "chrome_style": true
+    },
     "storage": {
         "managed_schema": "schema.json"
     },

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -36,6 +36,10 @@
             "description": "Scan a QR code"
         }
     },
+    "options_ui": {
+        "page": "view/options.html",
+        "browser_style": true
+    },
     "permissions": [
         "activeTab",
         "<all_urls>",

--- a/src/components/Options.vue
+++ b/src/components/Options.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <h2>{{ i18n.delete_all }}</h2>
+    <p>{{ i18n.delete_all_warning }}</p>
+    <input type="checkbox" id="checkbox" v-model="deleteConfirm" />
+    <label for="checkbox">{{ i18n.confirm_delete_all }}</label>
+    <br />
+    <br />
+    <button v-on:click="deleteEverything()" v-bind:disabled="!deleteConfirm">
+      {{ i18n.delete_all }}
+    </button>
+    <br />
+    <p v-show="deleteComplete">{{ i18n.updateSuccess }}</p>
+  </div>
+</template>
+<script lang="ts">
+import Vue from "vue";
+
+export default Vue.extend({
+  data: function() {
+    return {
+      deleteConfirm: false,
+      deleteComplete: false
+    };
+  },
+  methods: {
+    async deleteEverything() {
+      await new Promise((resolve: () => void) =>
+        chrome.storage.sync.clear(() => resolve())
+      );
+      await new Promise((resolve: () => void) =>
+        chrome.storage.local.clear(() => resolve())
+      );
+      localStorage.clear();
+      chrome.runtime.sendMessage({ action: "lock" });
+      this.deleteConfirm = false;
+      this.deleteComplete = true;
+    }
+  }
+});
+</script>

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,0 +1,14 @@
+import Vue from "vue";
+import OptionsView from "./components/Options.vue";
+import { loadI18nMessages } from "./store/i18n";
+
+async function init() {
+  // i18n
+  Vue.prototype.i18n = await loadI18nMessages();
+
+  new Vue({
+    render: h => h(OptionsView)
+  }).$mount("#options");
+}
+
+init();

--- a/view/options.html
+++ b/view/options.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+</head>
+
+<body>
+    <div id="options"></div>
+    <script src="../dist/options.js"></script>
+</body>
+
+</html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     content: "./src/content.ts",
     popup: "./src/popup.ts",
     import: "./src/import.ts",
+    options: "./src/options.ts",
     qrdebug: "./src/qrdebug.ts",
     test: "./src/test/test.ts"
   },


### PR DESCRIPTION
This adds an option to the extension settings UI (chrome://extensions, about:addons) so that users can reset Authenticator if they can't remember their password. 

| Chrome | Firefox |
| - | - |
| ![image](https://user-images.githubusercontent.com/27789806/80130266-ee055100-855d-11ea-9091-ddee3fd6fcb8.png) | ![image](https://user-images.githubusercontent.com/27789806/80130555-62d88b00-855e-11ea-95ef-8915cf8c7561.png) |

