### PR TITLE
Remove local file permission

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -52,8 +52,7 @@
     "permissions": [
         "activeTab",
         "storage",
-        "identity",
-        "file://*/*"
+        "identity"
     ],
     "optional_permissions": [
         "clipboardWrite",


### PR DESCRIPTION
We added local file permission (`file://*/*`) for https://github.com/Authenticator-Extension/Authenticator/issues/171, and merged the change with https://github.com/Authenticator-Extension/Authenticator/pull/173

This permission is required for some customer use cases (see also https://github.com/Authenticator-Extension/Authenticator/issues/400). From [this answer](https://stackoverflow.com/questions/19493020/adding-file-permission-to-chrome-extension/19493206#19493206) on StackOverflow, the local file permission must be approved by users manually.

However, recently we got [an issue](https://github.com/Authenticator-Extension/Authenticator/issues/510) to report a possible security issue of local file permission. Because Tabs permission could be granted by default:

> You can use most chrome.tabs methods and events without declaring any permissions in the extension's manifest file.
>
> https://developer.chrome.com/extensions/tabs

Extensions with local file permission are able to traverse local files by openning local file urls (for example `file:///C:/`) in new tabs, and read contents with active tab.

This is a serious security issue, and we need to discard `file://*/*` permission ASAP no matter it is disabled by default or not.

For importing data with local image files, we could add a new file input controller to make users be able to upload selected file to the extension as what a regular website does.