### PR TITLE
increase z-index to max value

### DIFF
--- a/sass/content.scss
+++ b/sass/content.scss
@@ -5,7 +5,7 @@
   width: 100%;
   height: 100%;
   background: rgba(255, 255, 255, 0.6);
-  z-index: 1000000;
+  z-index: 2147483647;
   display: none;
   cursor: crosshair;
 }


### PR DESCRIPTION
I recently encountered a modal that was activated by changing its z-index from -1 to 9999999999 and I was unable to scan the QR code since the extension only uses a z-index of 1000000.