### PR TITLE
Support hot reloading Chrome extension for development purposes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,6 @@ scripts
 webpack.config.js
 webpack.prod.js
 webpack.dev.js
+webpack.watch.js
 src/test
 src/models/credentials.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
-       "ecmaVersion": 6
+    "ecmaVersion": 6
   },
   plugins: [
     '@typescript-eslint',
@@ -14,10 +14,10 @@ module.exports = {
   ],
   env: {
     "amd": true,
-    "node": true  
+    "node": true,
   },
   rules: {
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/explicit-function-return-type": "off"
+    "@typescript-eslint/explicit-function-return-type": "off",
   }
 };

--- a/README.md
+++ b/README.md
@@ -15,4 +15,14 @@ npm install
 npm run [chrome, firefox]
 ```
 
+## Development (Chrome)
+
+``` bash
+# install development dependencies
+npm install 
+# compiles the Chrome extension to the `./test/chrome` directory
+npm run chrome:dev
+# load the unpacked extension from the `./test/chrome/ directory in Chrome
+```
+
 Note that Windows users should download a tool like [Git Bash](https://git-scm.com/download/win) or [Cygwin](http://cygwin.com/) to build.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm run [chrome, firefox]
 # install development dependencies
 npm install 
 # compiles the Chrome extension to the `./test/chrome` directory
-npm run chrome:dev
+npm run dev:chrome
 # load the unpacked extension from the `./test/chrome/ directory in Chrome
 ```
 

--- a/manifests/manifest-chrome-testing.json
+++ b/manifests/manifest-chrome-testing.json
@@ -65,5 +65,5 @@
     ],
     "offline_enabled": true,
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAjo5++7m6mlJGqKOnlYehr9tjIqahMZBJUG7PLa7dSRk6bDUu2pVodO1TQWviHlrDTLP+zfoVbDBS8v8cjloK5Tn90nzC6a957dPzOfyC1WUNYNDlGM0BCmZKVP/MWB3d0ffOmTwaxh0L47aLH5nTW0AUmuwCWCBEEl4Acuyp7rwLNGlazBpaom1Qb5ckn29gCJVVVIZ6wudmcrG/FPTNJXQbg8N6wObGrgGOaxmowbkzJmIfKTyHlYOKLAjZ7aJi0W6jsy47/aV+ojvn4gO+ka6BcRhUeWgoQxqEky119f3OWiVP46SJVbAi0pkknThUjDvX11lATGjB5EvJZGyotwIDAQAB",
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/; default-src 'none'"
+    "content_security_policy": "script-src 'self' 'unsafe-eval'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/ ws://localhost:9090; default-src 'none'"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -347,6 +347,12 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@types/anymatch": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+      "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA==",
+      "dev": true
+    },
     "@types/argon2-browser": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@types/argon2-browser/-/argon2-browser-1.12.0.tgz",
@@ -459,11 +465,81 @@
       "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
       "dev": true
     },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
+    "@types/tapable": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+      "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
+      "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.1.tgz",
+      "integrity": "sha512-7npvPKV+jINLu1SpSYVWG8KvyJBhBa8tmzMMdDoVc2pWUYHN8KIXlPJhjJ4LT97c4dXJA2SHL/q6ADbDriZN+Q==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "@types/uuid": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz",
       "integrity": "sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==",
       "dev": true
+    },
+    "@types/webpack": {
+      "version": "4.41.25",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.25.tgz",
+      "integrity": "sha512-cr6kZ+4m9lp86ytQc1jPOJXgINQyz3kLLunZ57jznW+WIAL0JqZbGubQk4GlD42MuQL5JGOABrxdpqqWeovlVQ==",
+      "dev": true,
+      "requires": {
+        "@types/anymatch": "*",
+        "@types/node": "*",
+        "@types/tapable": "*",
+        "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.8.tgz",
+      "integrity": "sha512-JHB2/xZlXOjzjBB6fMOpH1eQAfsrpqVVIbneE0Rok16WXwFaznaI5vfg75U5WgGJm7V9W1c4xeRQDjX/zwvghA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "@types/yauzl": {
       "version": "2.9.1",
@@ -1642,6 +1718,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "combined-stream": {
@@ -7371,6 +7453,16 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
+    "useragent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
+    },
     "util": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
@@ -7660,6 +7752,12 @@
         }
       }
     },
+    "webextension-polyfill": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.5.0.tgz",
+      "integrity": "sha512-aFrl38x43t1bTboX/paCT8I97+idzX/TY0+fuM52hrIkCpYfROEF9kSn0BXuEIi3J9LTYt2ZZKkhx9NB1qF3nA==",
+      "dev": true
+    },
     "webpack": {
       "version": "4.44.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
@@ -7895,6 +7993,23 @@
             "decamelize": "^1.2.0"
           }
         }
+      }
+    },
+    "webpack-extension-reloader": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/webpack-extension-reloader/-/webpack-extension-reloader-1.1.4.tgz",
+      "integrity": "sha512-PyssJvAiKhztc//QmhpU8yfg7LBR7Bn/cjSM7jadfQJPIDNN1Djxc+SJQRk8uHQ3GQbyWhsWu2DLCMBRcWHIPA==",
+      "dev": true,
+      "requires": {
+        "@types/webpack": "^4.39.8",
+        "@types/webpack-sources": "^0.1.5",
+        "colors": "^1.4.0",
+        "lodash": "^4.17.15",
+        "minimist": "^1.2.0",
+        "useragent": "^2.3.0",
+        "webextension-polyfill": "^0.5.0",
+        "webpack-sources": "^1.4.3",
+        "ws": "^7.2.0"
       }
     },
     "webpack-merge": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Authenticator generates 2-Step Verification codes in your browser.",
   "scripts": {
     "compile": "bash scripts/build.sh firefox",
+    "dev:chrome": "npm run pretest && webpack --config ./webpack.watch.js",
     "chrome": "bash scripts/build.sh chrome",
     "firefox": "bash scripts/build.sh firefox",
     "prod": "bash scripts/build.sh prod",
@@ -55,6 +56,7 @@
     "vue-template-compiler": "^2.6.12",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.11",
+    "webpack-extension-reloader": "^1.1.4",
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -83,8 +83,6 @@ postCompile () {
     if [[ $1 = "chrome" ]]; then
         cp manifests/schema-chrome.json $1/schema.json
     fi
-
-    
 }
 
 if [[ $PLATFORM = "prod" ]]; then

--- a/scripts/test-runner.ts
+++ b/scripts/test-runner.ts
@@ -39,6 +39,8 @@ async function runTests() {
     ignoreDefaultArgs: ["--disable-extensions"],
     args: [
       `--load-extension=${path.resolve(__dirname, "../test/chrome")}`,
+      // prevents zombie Chromium processes from not terminating during development testing
+      "--single-process",
       // for CI
       "--no-sandbox",
     ],

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,11 +1,10 @@
 const path = require("path");
 const merge = require('webpack-merge');
 const common = require('./webpack.config.js');
-const webpack = require('webpack');
 
 module.exports = merge(common, {
   entry: {
-    test: "./src/test.ts"
+    test: "./src/test.ts",
   },
   module: {
     rules: [
@@ -23,7 +22,7 @@ module.exports = merge(common, {
         enforce: "post"
       }
     ],
-    // to supress mocha warnings
+    // to suppress mocha warnings
     exprContextCritical: false,
   }
 });

--- a/webpack.watch.js
+++ b/webpack.watch.js
@@ -1,0 +1,36 @@
+const path = require('path');
+const merge = require('webpack-merge');
+const dev = require('./webpack.dev.js');
+const ExtensionReloader = require('webpack-extension-reloader');
+const {exec} = require('child_process');
+
+// after compiling, the tests will automatically be run each time a file change occurs
+const runTestsAfterBuild = () => {
+  return {
+    apply: (compiler) => {
+      compiler.hooks.afterEmit.tap('AfterEmitPlugin', () => {
+        // leave as node otherwise browser does not launch
+        exec('node scripts/test-runner.js', (err, stdout, stderr) => {
+          if (stdout) process.stdout.write(stdout);
+          if (stderr) process.stderr.write(stderr);
+        });
+      });
+    }
+  }
+};
+
+module.exports = merge(dev, {
+  mode: 'development',
+  plugins: [
+    new ExtensionReloader(),
+    runTestsAfterBuild(),
+  ],
+  watch: true,
+  watchOptions: {
+    ignored: /node_modules/
+  },
+  output: {
+    path: path.resolve(__dirname, 'test/chrome/dist'),
+    publicPath: '/test/chrome/dist/'
+  }
+});


### PR DESCRIPTION
By running `npm run dev:chrome`, hot reloading the extension occurs
when one of the `./src` files is changed.  Allows for quicker
development and testing occurs on file change as well

# Description
I didn't see an option for hot reloading the extension or how to develop.  So I added a way.
This requires an additional webpack file because if we watch with the `dev` script the rest of the commands in `build.sh` does not get executed

# Changes
- Adds the ability to hot reload the extension on code changes
- On reload of the extension, the test suite is run.  Allows the developer to know if their changes are breaking things faster.
- Update the README on how to develop