### PR TITLE
Move AddMethodPage to header

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,10 @@
         "message": "Invalid account secret",
         "description": "Secret Error."
     },
+    "add_code": {
+        "message": "Add code",
+        "description": "Add code."
+    },
     "add_qr": {
         "message": "Scan QR Code",
         "description": "Scan QR Code."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -24,8 +24,8 @@
         "description": "Secret Error."
     },
     "add_code": {
-        "message": "Add code",
-        "description": "Add code."
+        "message": "Add account",
+        "description": "Add account."
     },
     "add_qr": {
         "message": "Scan QR Code",

--- a/sass/popup.scss
+++ b/sass/popup.scss
@@ -66,7 +66,8 @@ svg {
   }
 }
 
-#i-menu {
+#i-menu,
+#i-plus {
   position: absolute;
   left: 20px;
   bottom: 0;

--- a/sass/popup.scss
+++ b/sass/popup.scss
@@ -66,8 +66,7 @@ svg {
   }
 }
 
-#i-menu,
-#i-plus {
+#i-menu {
   position: absolute;
   left: 20px;
   bottom: 0;
@@ -95,6 +94,7 @@ svg {
   }
 }
 
+#i-plus,
 #i-qr {
   position: absolute;
   right: 45px;

--- a/src/components/Popup/MainBody.vue
+++ b/src/components/Popup/MainBody.vue
@@ -39,9 +39,6 @@
         v-bind:entry="entry"
       />
     </div>
-    <div class="icon" id="add" v-on:click="showInfo('AddMethodPage')">
-      <IconPlus />
-    </div>
   </div>
 </template>
 <script lang="ts">
@@ -69,19 +66,6 @@ export default Vue.extend({
   },
   computed,
   methods: {
-    showInfo(page: string) {
-      if (page === "AddMethodPage") {
-        if (
-          this.$store.state.menu.enforcePassword &&
-          !this.$store.state.accounts.encryption.getEncryptionStatus()
-        ) {
-          page = "SetPasswordPage";
-        }
-      }
-
-      this.$store.commit("style/showInfo");
-      this.$store.commit("currentView/changeView", page);
-    },
     isMatchedEntry(entry: OTPEntry) {
       for (const hash of this.$store.getters["accounts/matchedEntries"]) {
         if (entry.hash === hash) {

--- a/src/components/Popup/MainHeader.vue
+++ b/src/components/Popup/MainHeader.vue
@@ -14,7 +14,7 @@
       <div
         class="icon"
         id="i-plus"
-        v-bind:title="i18n.settings"
+        v-bind:title="i18n.add_code"
         v-on:click="showInfo('AddMethodPage')"
         v-show="style.isEditing"
       >

--- a/src/components/Popup/MainHeader.vue
+++ b/src/components/Popup/MainHeader.vue
@@ -13,6 +13,15 @@
       </div>
       <div
         class="icon"
+        id="i-plus"
+        v-bind:title="i18n.settings"
+        v-on:click="showInfo('AddMethodPage')"
+        v-show="style.isEditing"
+      >
+        <IconPlus />
+      </div>
+      <div
+        class="icon"
         id="i-lock"
         v-bind:title="i18n.lock"
         v-on:click="lock()"
@@ -74,6 +83,7 @@ import IconSync from "../../../svg/sync.svg";
 import IconScan from "../../../svg/scan.svg";
 import IconPencil from "../../../svg/pencil.svg";
 import IconCheck from "../../../svg/check.svg";
+import IconPlus from "../../../svg/plus.svg";
 
 const computedPrototype = [
   mapState("style", ["style"]),
@@ -111,6 +121,18 @@ export default Vue.extend({
     },
     showMenu() {
       this.$store.commit("style/showMenu");
+    },
+    showInfo(page: string) {
+      if (page === "AddMethodPage") {
+        if (
+          this.$store.state.menu.enforcePassword &&
+          !this.$store.state.accounts.encryption.getEncryptionStatus()
+        ) {
+          page = "SetPasswordPage";
+        }
+      }
+      this.$store.commit("style/showInfo");
+      this.$store.commit("currentView/changeView", page);
     },
     editEntry() {
       this.$store.commit("style/toggleEdit");
@@ -173,7 +195,8 @@ export default Vue.extend({
     IconSync,
     IconScan,
     IconPencil,
-    IconCheck
+    IconCheck,
+    IconPlus
   }
 });
 </script>


### PR DESCRIPTION
Makes it more accessible and not require the user to scroll through
their list to add a new one

# Description

If a user has many codes, it requires them to scroll through the list before they can add another one.  I am one of those users.
This fixes this issue by moving the add button to the header.  I removed the one at the bottom of the list.

## Old way

![Mf4D0vEG7Y](https://user-images.githubusercontent.com/5728044/102354102-1708a500-3f78-11eb-989d-a441e41ca95e.png)

## New way

![OuVRWEG6Ly](https://user-images.githubusercontent.com/5728044/102354110-1a9c2c00-3f78-11eb-9a23-c8c6430d9366.png)

## New way (after clicking button)

![GaBHDfKV4I](https://user-images.githubusercontent.com/5728044/102354198-3dc6db80-3f78-11eb-9026-9250a206a6ac.png)
