### PR TITLE
Fix encodeURIComponent in otpauth URI

### DIFF
--- a/src/components/Popup/EntryComponent.vue
+++ b/src/components/Popup/EntryComponent.vue
@@ -264,7 +264,9 @@ function getQrUrl(entry: OTPEntry) {
     encodeURIComponent(label) +
     "?secret=" +
     entry.secret +
-    (entry.issuer ? "&issuer=" + encodeURIComponent(entry.issuer.split("::")[0]) : "") +
+    (entry.issuer
+      ? "&issuer=" + encodeURIComponent(entry.issuer.split("::")[0])
+      : "") +
     (entry.type === OTPType.hotp || entry.type === OTPType.hhex
       ? "&counter=" + entry.counter
       : "") +

--- a/src/components/Popup/EntryComponent.vue
+++ b/src/components/Popup/EntryComponent.vue
@@ -261,10 +261,10 @@ function getQrUrl(entry: OTPEntry) {
     "otpauth://" +
     type +
     "/" +
-    label +
+    encodeURIComponent(label) +
     "?secret=" +
     entry.secret +
-    (entry.issuer ? "&issuer=" + entry.issuer.split("::")[0] : "") +
+    (entry.issuer ? "&issuer=" + encodeURIComponent(entry.issuer.split("::")[0]) : "") +
     (entry.type === OTPType.hotp || entry.type === OTPType.hhex
       ? "&counter=" + entry.counter
       : "") +


### PR DESCRIPTION
Fixed to properly escape `label` and `issuer` when the extension displays QR codes for otpauth URLs.

For example, if the `issuer` contained `&`, the QR code would not be read properly by Apps on iOS and Android. 
White-spaces and some symbols would cause same problem.

