### PR TITLE
Notice user to use import local file instead of scanning local files

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -193,6 +193,10 @@
         "message": "Capture failed, please reload the page and try again.",
         "description": "Capture Failed"
     },
+    "capture_local_file_failed": {
+        "message": "Are you trying to scan QR code from a local file? Use Import QR Image Backup instead.",
+        "description": "Import QR image backup instead of scan local image"
+    },
     "based_on_time": {
         "message": "Time Based",
         "description": "Time Based"

--- a/package-lock.json
+++ b/package-lock.json
@@ -403,7 +403,7 @@
     },
     "@types/filewriter": {
       "version": "0.0.28",
-      "resolved": "http://registry.npm.taobao.org/@types/filewriter/download/@types/filewriter-0.0.28.tgz",
+      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.28.tgz",
       "integrity": "sha1-wFTor02d11205jq8dviFFocU1LM=",
       "dev": true
     },

--- a/src/components/Import.vue
+++ b/src/components/Import.vue
@@ -47,8 +47,12 @@ import TextImport from "./Import/TextImport.vue";
 
 export default Vue.extend({
   data: function () {
+    const query = location.search ? location.search.substr(1) : "";
+    const importType = ["FileImport", "QrImport", "TextImport"].includes(query)
+      ? query
+      : "FileImport";
     return {
-      importType: "FileImport",
+      importType,
       shouldShowPassphrase: shouldShowPassphrase(this.$entries),
     };
   },


### PR DESCRIPTION
Because we have deprecated `file://` permission in the recent version, and some user use scanning local file to import backups heavily, we need popup a notification and guide the user to use import tool for local QR images.

![Snipaste_2021-02-08_13-40-08](https://user-images.githubusercontent.com/1621293/107180231-433e2080-6a13-11eb-9e38-d1ee40edee22.png)

![Snipaste_2021-02-08_13-40-29](https://user-images.githubusercontent.com/1621293/107180242-49340180-6a13-11eb-8bd5-22d657b4ff8b.png)
