### PR TITLE
Added password field to prepend to otp when copying to clipboard

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/ca/messages.json
+++ b/_locales/ca/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Fes una còpia de les dades a un fitxer."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Sichern Sie Ihre Daten in eine Datei."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Guarda en un archivo una copia de seguridad de tus datos."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/et/messages.json
+++ b/_locales/et/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Varundage enda andmed failiks."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "ایجاد فایل پشتیبان از داده‌های شما"
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Sauvegardez vos données dans un fichier."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/fy/messages.json
+++ b/_locales/fy/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Meitsje in reservekopy fan jo gegevens nei in bestân."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "גיבוי הנתונים שלך לקובץ."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Spremanje podataka u sigurnosnu kopiju."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Cadangkan data Anda ke file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Fai il backup dei tuoi dati su un file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "データをファイルにバックアップします。"
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Back-up uw gegevens naar een bestand."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Utwórz kopię zapasową danych w pliku."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/pt/messages.json
+++ b/_locales/pt/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Faça backup dos seus dados para um arquivo."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Salvați datele într-un fișier."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/sq/messages.json
+++ b/_locales/sq/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Krijo një kopje rezervë të të dhënave tuaja në një skedar."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Спреми податке у резервну копију."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/th/messages.json
+++ b/_locales/th/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "สำรองข้อมูลของคุณลงในไฟล์"
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Verilerinizi bir dosyaya yedekleyin."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Backup your data to a file."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "Sao chép dữ liệu thành 1 tệp tin."
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "备份数据到文件。"
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -389,5 +389,8 @@
     },
     "backup_file_info": {
         "message": "備份至檔案"
+    },
+    "password": {
+        "message": "password"
     }
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -177,6 +177,7 @@ async function getTotp(text: string, silent = false) {
     } else {
       let secret = "";
       let account: string | undefined;
+      let password: string | undefined;
       let issuer: string | undefined;
       let algorithm: string | undefined;
       let period: number | undefined;
@@ -250,6 +251,7 @@ async function getTotp(text: string, silent = false) {
         const entryData: { [hash: string]: OTPStorage } = {};
         entryData[hash] = {
           account,
+          password,
           hash,
           issuer,
           secret,

--- a/src/components/Popup/AddAccountPage.vue
+++ b/src/components/Popup/AddAccountPage.vue
@@ -51,6 +51,7 @@ export default Vue.extend({
     newAccount: {
       issuer: string;
       account: string;
+      password: string;
       secret: string;
       type: OTPType;
       period: number | undefined;
@@ -62,6 +63,7 @@ export default Vue.extend({
       newAccount: {
         issuer: "",
         account: "",
+        password: "",
         secret: "",
         type: OTPType.totp,
         period: undefined,
@@ -119,6 +121,7 @@ export default Vue.extend({
           index: 0,
           issuer: this.newAccount.issuer,
           account: this.newAccount.account,
+          password: this.newAccount.password,
           encrypted: false,
           secret: this.newAccount.secret,
           counter: 0,

--- a/src/components/Popup/BackupPage.vue
+++ b/src/components/Popup/BackupPage.vue
@@ -168,6 +168,9 @@ function getOneLineOtpBackupFile(entryData: { [hash: string]: OTPStorage }) {
     if (otpStorage.account) {
       otpStorage.account = removeUnsafeData(otpStorage.account);
     }
+    if (otpStorage.password) {
+      otpStorage.password = removeUnsafeData(otpStorage.password);
+    }
     const label = otpStorage.issuer
       ? otpStorage.issuer + ":" + (otpStorage.account || "")
       : otpStorage.account || "";

--- a/src/components/Popup/EntryComponent.vue
+++ b/src/components/Popup/EntryComponent.vue
@@ -55,6 +55,15 @@
         v-on:change="entry.update(encryption)"
       />
     </div>
+    <div class="issuer">{{ hideText(entry.password) }}</div>
+    <div class="issuerEdit">
+      <input
+        v-bind:placeholder="i18n.password"
+        type="text"
+        v-model="entry.password"
+        v-on:change="entry.update(encryption)"
+      />
+    </div>
     <div
       class="showqr"
       v-if="shouldShowQrIcon(entry)"
@@ -143,6 +152,9 @@ export default Vue.extend({
 
       return new Array(entry.digits).fill("&bull;").join("");
     },
+    hideText(text: string) {
+      return new Array(text.length).fill("*").join("");
+    },
     async removeEntry(entry: OTPEntry) {
       if (
         await this.$store.dispatch(
@@ -222,7 +234,7 @@ export default Vue.extend({
               );
             }
 
-            codeClipboard.value = entry.code;
+            codeClipboard.value = entry.password + entry.code;
             codeClipboard.focus();
             codeClipboard.select();
             document.execCommand("Copy");

--- a/src/components/Popup/MainBody.vue
+++ b/src/components/Popup/MainBody.vue
@@ -80,7 +80,8 @@ export default Vue.extend({
       }
       if (
         entry.issuer.toLowerCase().includes(this.searchText.toLowerCase()) ||
-        entry.account.toLowerCase().includes(this.searchText.toLowerCase())
+        entry.account.toLowerCase().includes(this.searchText.toLowerCase()) ||
+        entry.password.toLowerCase().includes(this.searchText.toLowerCase())
       ) {
         return true;
       } else {

--- a/src/definitions/otp.d.ts
+++ b/src/definitions/otp.d.ts
@@ -5,6 +5,7 @@ interface OTPEntryInterface {
   encSecret: string | null;
   secret: string | null;
   account: string;
+  password: string;
   hash: string;
   counter: number;
   code: string;
@@ -31,6 +32,7 @@ interface EncryptionInterface {
 
 interface OTPStorage {
   account?: string;
+  password?: string;
   encrypted: boolean;
   hash: string;
   index: number;

--- a/src/import.ts
+++ b/src/import.ts
@@ -121,6 +121,7 @@ export async function getEntryDataFromOTPAuthPerLine(importCode: string) {
     } else {
       let secret = "";
       let account: string | undefined;
+      let password: string | undefined;
       let issuer: string | undefined;
       let algorithm: string | undefined;
       let period: number | undefined;
@@ -195,6 +196,7 @@ export async function getEntryDataFromOTPAuthPerLine(importCode: string) {
 
         exportData[hash] = {
           account,
+          password,
           hash,
           issuer,
           secret,

--- a/src/models/otp.ts
+++ b/src/models/otp.ts
@@ -30,6 +30,7 @@ export class OTPEntry implements OTPEntryInterface {
   secret: string | null;
   encSecret: string | null;
   account: string;
+  password: string;
   hash: string;
   counter: number;
   period: number;
@@ -41,6 +42,7 @@ export class OTPEntry implements OTPEntryInterface {
   constructor(
     entry: {
       account?: string;
+      password?: string;
       encrypted: boolean;
       index: number;
       issuer?: string;
@@ -66,6 +68,11 @@ export class OTPEntry implements OTPEntryInterface {
       this.account = entry.account;
     } else {
       this.account = "";
+    }
+    if (entry.password) {
+      this.password = entry.password;
+    } else {
+      this.password = "";
     }
     if (entry.encrypted) {
       this.encSecret = entry.secret;

--- a/src/models/storage.ts
+++ b/src/models/storage.ts
@@ -195,6 +195,10 @@ export class EntryStorage {
       storageItem.account = entry.account;
     }
 
+    if (entry.password) {
+      storageItem.password = entry.password;
+    }
+
     if (entry.digits && entry.digits !== 6) {
       storageItem.digits = entry.digits;
     }
@@ -340,6 +344,10 @@ export class EntryStorage {
                 delete _data[hash].account;
               }
 
+              if (!_data[hash].password) {
+                delete _data[hash].password;
+              }
+
               if (_data[hash].digits === 6) {
                 delete _data[hash].digits;
               }
@@ -397,6 +405,7 @@ export class EntryStorage {
 
               data[hash].hash = data[hash].hash || hash;
               data[hash].account = data[hash].account || "";
+              data[hash].password = data[hash].password || "";
               data[hash].encrypted = encryption.getEncryptionStatus();
               data[hash].index = data[hash].index || 0;
               data[hash].issuer = data[hash].issuer || "";
@@ -603,6 +612,7 @@ export class EntryStorage {
 
               const entry = new OTPEntry({
                 account: entryData.account,
+                password: entryData.password,
                 encrypted: entryData.encrypted,
                 hash: entryData.hash,
                 index: entryData.index,


### PR DESCRIPTION
Some providers use to concatenate the password and the otp, this makes it more convenient.
This work was done for myself, quick and dirty, but with your help might become useful to others.

<img width="322" alt="Schermata 2021-04-29 alle 16 39 22" src="https://user-images.githubusercontent.com/17740085/116569344-984e4c00-a909-11eb-92b4-c8af824364f2.png">
<img width="322" alt="Schermata 2021-04-29 alle 16 39 56" src="https://user-images.githubusercontent.com/17740085/116569350-997f7900-a909-11eb-9429-9c097e015809.png">

