### PR TITLE
Add webstore deployment action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Webstore
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build ${{ matrix.platform }}
+
+    strategy:
+      matrix:
+        platform: ["chrome", "firefox"]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run ${{ matrix.platform }}
+
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v0.0.0
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Hiya,

We built a [GH action](https://github.com/plasmo-corp/bpp) that makes deploying to the various webstores easier. I created a GH action here that uses it. So after the build step, it'll run our thing that deploys the generated ZIP files (the location of which you need to specifiy in `SUBMIT_KEYS`) to Chrome and AMO stores.

It looks like y'all [don't wanna auto-release](https://github.com/Authenticator-Extension/Authenticator/issues/68), so I made it a manual process, instead of auto-release. 

For this PR to actually pass and not error, y'all gotta create a SUBMIT_KEYS github repository secret.

This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/main/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "extId": "123",
    "sessionid": "abcd"
  }
}
```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help, lmk!