### PR TITLE
Add 'wasm-unsafe-eval' to custom CSP (fix #906)

### DIFF
--- a/manifests/manifest-firefox.json
+++ b/manifests/manifest-firefox.json
@@ -57,5 +57,5 @@
         "https://graph.microsoft.com/me/*",
         "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     ],
-    "content_security_policy": "script-src 'self'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/; default-src 'none'"
+    "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/; default-src 'none'"
 }


### PR DESCRIPTION
It seems that some dependencies (at least argon2-browser) require allowing WebAssembly at the CSP level.
Recent Firefox allows that by default, but having your own CSP means this extension won't be able to benefit from this automatically.