### PR TITLE
Use more restrictive CSP in Chromium

### DIFF
--- a/manifests/manifest-chrome.json
+++ b/manifests/manifest-chrome.json
@@ -50,7 +50,7 @@
         "pages": [
             "view/argon.html"
         ],
-        "content_security_policy": "sandbox allow-scripts; script-src 'self' 'unsafe-eval';"
+        "content_security_policy": "sandbox allow-scripts; script-src 'self' 'wasm-unsafe-eval';"
     },
     "permissions": [
         "activeTab",
@@ -68,5 +68,6 @@
         "https://login.microsoftonline.com/common/oauth2/v2.0/token"
     ],
     "offline_enabled": true,
+    "minimum_chrome_version": "103",
     "content_security_policy": "script-src 'self'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/; default-src 'none'"
 }


### PR DESCRIPTION
We may want to wait a while or save this for the MV3 transition due to the minimum version requirement.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#webassembly