### PR TITLE
Implement work-around/fix for incorrect render of manually added HOTP tokens

### DIFF
--- a/src/components/Popup/AddAccountPage.vue
+++ b/src/components/Popup/AddAccountPage.vue
@@ -33,7 +33,7 @@
         <option :value="OTPAlgorithm.GOST3411_2012_256">GOST 34.11 256</option>
         <option :value="OTPAlgorithm.GOST3411_2012_512">GOST 34.11 512</option>
       </a-select-input>
-      <a-select-input :label="i18n.type" v-model="newAccount.type">
+      <a-select-input :label="i18n.type" v-model.number="newAccount.type">
         <option :value="OTPType.totp">{{ i18n.based_on_time }}</option>
         <option :value="OTPType.hotp">{{ i18n.based_on_counter }}</option>
         <option :value="OTPType.battle">Battle.net</option>
@@ -103,7 +103,7 @@ export default Vue.extend({
       ) {
         type = OTPType.hhex;
       } else {
-        type = parseInt(this.newAccount.type);
+        type = this.newAccount.type;
       }
 
       if (type === OTPType.hhex || type === OTPType.hotp) {

--- a/src/components/Popup/AddAccountPage.vue
+++ b/src/components/Popup/AddAccountPage.vue
@@ -103,7 +103,7 @@ export default Vue.extend({
       ) {
         type = OTPType.hhex;
       } else {
-        type = this.newAccount.type;
+        type = parseInt(this.newAccount.type);
       }
 
       if (type === OTPType.hhex || type === OTPType.hotp) {


### PR DESCRIPTION
The parsed `<option>` returns the OTP.type as a string, instead of the required integer type. Later in execution, the code can't handle the string in comparisons, etc. 

As a result, selecting a different type causes the resulting entry to be handled as a standard TOTP type. Giving it the appearance and behaviour as such - it also affects backups (..`&counter=undefined`) if done so in the same session. 
Any type of operation apart from the default type (as that's assigned an integer by default) with the option is affected. 
![image](https://github.com/Authenticator-Extension/Authenticator/assets/76943372/83ce20ef-3eb7-43ef-bfc7-87ec9d044491)


In saying that, once reloaded, some other part of the code corrects the entry and storage. 


This just parseInts the string so that it's correctly handled.
You might have some better way of doing this, perhaps earlier on, etc. 

