### PR TITLE
Make firefox min version 126

### DIFF
--- a/manifests/manifest-firefox.json
+++ b/manifests/manifest-firefox.json
@@ -1,66 +1,56 @@
 {
-    "manifest_version": 3,
-    "name": "__MSG_extName__",
-    "short_name": "__MSG_extShortName__",
-    "version": "7.0.0",
-    "default_locale": "en",
-    "description": "__MSG_extDesc__",
-    "browser_specific_settings": {
-        "gecko": {
-            "id": "authenticator@mymindstorm",
-            "strict_min_version": "109.0"
-        }
-    },
-    "icons": {
-        "16": "images/icon16.png",
-        "48": "images/icon48.png",
-        "128": "images/icon128.png"
-    },
-    "action": {
-        "default_icon": {
-            "19": "images/icon19.png",
-            "38": "images/icon38.png"
-        },
-        "default_title": "__MSG_extShortName__",
-        "default_popup": "view/popup.html"
-    },
-    "background": {
-        "scripts": [
-            "dist/background.js"
-        ]
-    },
-    "commands": {
-        "_execute_browser_action": {},
-        "scan-qr": {
-            "description": "Scan a QR code"
-        },
-        "autofill": {
-            "description": "Autofill the matched code"
-        }
-    },
-    "options_ui": {
-        "page": "view/options.html",
-        "open_in_tab": false
-    },
-    "permissions": [
-        "activeTab",
-        "storage",
-        "identity",
-        "alarms",
-        "scripting"
-    ],
-    "optional_permissions": [
-        "clipboardWrite"
-    ],
-    "host_permissions": [
-        "https://www.google.com/",
-        "https://*.dropboxapi.com/*",
-        "https://www.googleapis.com/*",
-        "https://accounts.google.com/o/oauth2/revoke",
-        "https://graph.microsoft.com/me/*",
-        "https://login.microsoftonline.com/common/oauth2/v2.0/token"
-    ],
-    "content_security_policy": {
-        "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/; default-src 'none'"
+  "manifest_version": 3,
+  "name": "__MSG_extName__",
+  "short_name": "__MSG_extShortName__",
+  "version": "7.0.0",
+  "default_locale": "en",
+  "description": "__MSG_extDesc__",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "authenticator@mymindstorm",
+      "strict_min_version": "126.0"
     }
+  },
+  "icons": {
+    "16": "images/icon16.png",
+    "48": "images/icon48.png",
+    "128": "images/icon128.png"
+  },
+  "action": {
+    "default_icon": {
+      "19": "images/icon19.png",
+      "38": "images/icon38.png"
+    },
+    "default_title": "__MSG_extShortName__",
+    "default_popup": "view/popup.html"
+  },
+  "background": {
+    "scripts": ["dist/background.js"]
+  },
+  "commands": {
+    "_execute_browser_action": {},
+    "scan-qr": {
+      "description": "Scan a QR code"
+    },
+    "autofill": {
+      "description": "Autofill the matched code"
+    }
+  },
+  "options_ui": {
+    "page": "view/options.html",
+    "open_in_tab": false
+  },
+  "permissions": ["activeTab", "storage", "identity", "alarms", "scripting"],
+  "optional_permissions": ["clipboardWrite"],
+  "host_permissions": [
+    "https://www.google.com/",
+    "https://*.dropboxapi.com/*",
+    "https://www.googleapis.com/*",
+    "https://accounts.google.com/o/oauth2/revoke",
+    "https://graph.microsoft.com/me/*",
+    "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; font-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src https://www.google.com/ https://*.dropboxapi.com https://www.googleapis.com/ https://accounts.google.com/o/oauth2/revoke https://login.microsoftonline.com/common/oauth2/v2.0/token https://graph.microsoft.com/; default-src 'none'"
+  }
 }


### PR DESCRIPTION
In Firefox 125 and earlier, captureVisibleTab required `<all_urls>`.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/captureVisibleTab