### PR TITLE
Fix toolbar button shortcut (#1274)

### DIFF
--- a/manifests/manifest-firefox.json
+++ b/manifests/manifest-firefox.json
@@ -28,7 +28,7 @@
     "scripts": ["dist/background.js"]
   },
   "commands": {
-    "_execute_browser_action": {},
+    "_execute_action": {},
     "scan-qr": {
       "description": "Scan a QR code"
     },


### PR DESCRIPTION
Fix #1274 Since manifest v3 `execute_browser_action` is no longer available, use the `execute_action` command instead
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands