### PR TITLE
[FIX] Seconds not properly prevented from being negative

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+*.disabled

--- a/src/store/Accounts.ts
+++ b/src/store/Accounts.ts
@@ -90,10 +90,10 @@ export class Accounts implements Module {
           }
 
           if (second < 0) {
-            // Handle the situation where offset causes `second` to be negative. #1310 
-            second = 60 - ((second * -1) % 60)
+            // Handle the situation where offset causes `second` to be negative. #1310
+            second = 60 - ((second * -1) % 60);
           } else {
-            second = second % 60
+            second = second % 60;
           }
           state.second = second;
 

--- a/src/store/Accounts.ts
+++ b/src/store/Accounts.ts
@@ -89,8 +89,12 @@ export class Accounts implements Module {
             second += Number(UserSettings.items.offset);
           }
 
-          // prevent second from negative
-          second = (second < 0) ? (60 - (second * -1) % 60) : (second % 60);
+          if (second < 0) {
+            // Handle the situation where offset causes `second` to be negative. #1310 
+            second = 60 - ((second * -1) % 60)
+          } else {
+            second = second % 60
+          }
           state.second = second;
 
           let currentlyEncrypted = false;

--- a/src/store/Accounts.ts
+++ b/src/store/Accounts.ts
@@ -90,7 +90,7 @@ export class Accounts implements Module {
             second += Number(UserSettings.items.offset) + 60;
           }
 
-          second = second % 60;
+          second = (second < 0) ? (60 - (second * -1) % 60) : (second % 60);
           state.second = second;
 
           let currentlyEncrypted = false;

--- a/src/store/Accounts.ts
+++ b/src/store/Accounts.ts
@@ -87,7 +87,7 @@ export class Accounts implements Module {
           let second = new Date().getSeconds();
           if (UserSettings.items.offset) {
             // prevent second from negative
-            second += Number(UserSettings.items.offset) + 60;
+            second += Number(UserSettings.items.offset);
           }
 
           second = (second < 0) ? (60 - (second * -1) % 60) : (second % 60);

--- a/src/store/Accounts.ts
+++ b/src/store/Accounts.ts
@@ -86,10 +86,10 @@ export class Accounts implements Module {
         updateCodes(state: AccountsState) {
           let second = new Date().getSeconds();
           if (UserSettings.items.offset) {
-            // prevent second from negative
             second += Number(UserSettings.items.offset);
           }
 
+          // prevent second from negative
           second = (second < 0) ? (60 - (second * -1) % 60) : (second % 60);
           state.second = second;
 


### PR DESCRIPTION
The current code ...

https://github.com/Authenticator-Extension/Authenticator/blob/6511920bac98576e3c97fe2d213b23e9dc899422/src/store/Accounts.ts#L90

... fails in these two examples:

```
0 - 61 + 60 < 0
59 - 120 + 60 < 0
```

The offset (middle value) can be as low as `-300`.

https://github.com/Authenticator-Extension/Authenticator/blob/6511920bac98576e3c97fe2d213b23e9dc899422/src/syncTime.ts#L27

So the least you can have is `-241 (59 - 300)`, the `+ 60` is not enough to make a positive number.

---

Without this fix, in the examples given above, the effect will be:

Countdown circle animation may be out of sync with the current time step because `animationDelay` will be stuck at `0s`.

https://github.com/Authenticator-Extension/Authenticator/blob/6511920bac98576e3c97fe2d213b23e9dc899422/src/components/Popup/EntryComponent.vue#L22-L29

`timeout` class will never activate unless `entry.period < 5` because the left side of the `<` condition will be stuck at `entry.period`.

https://github.com/Authenticator-Extension/Authenticator/blob/6511920bac98576e3c97fe2d213b23e9dc899422/src/components/Popup/EntryComponent.vue#L59