### PR TITLE
fix code auto-pasting by using better heuristics to find the input box

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -283,69 +283,29 @@ async function qrDecode(
 }
 
 function pasteCode(code: string) {
-  const _inputBoxes = document.getElementsByTagName("input");
-  const inputBoxes: HTMLInputElement[] = [];
-  for (let i = 0; i < _inputBoxes.length; i++) {
-    if (
-      _inputBoxes[i].type === "text" ||
-      _inputBoxes[i].type === "number" ||
-      _inputBoxes[i].type === "tel" ||
-      _inputBoxes[i].type === "password"
-    ) {
-      inputBoxes.push(_inputBoxes[i]);
-    }
-  }
-  if (!inputBoxes.length) {
-    return;
-  }
-  const identities = [
-    "2fa",
-    "otp",
-    "authenticator",
-    "factor",
-    "code",
-    "totp",
-    "twoFactorCode",
-  ];
-  for (const inputBox of inputBoxes) {
-    for (const identity of identities) {
-      if (
-        inputBox.name.toLowerCase().indexOf(identity) >= 0 ||
-        inputBox.id.toLowerCase().indexOf(identity) >= 0
-      ) {
-        if (!inputBox.value || /^(\d{6}|\d{8})$/.test(inputBox.value)) {
-          inputBox.value = code;
-          fireInputEvents(inputBox);
-        }
-        return;
-      }
-    }
+  const selector =
+    "input[type=text], input[type=number], input[type=tel], input[type=password]";
+  const isValidInput = (input: HTMLInputElement) =>
+    input.checkVisibility() &&
+    (!input.value || /^(\d{6}|\d{8}|[A-Z\d]{5})$/.test(input.value));
+  let input: HTMLInputElement | undefined;
+
+  if (
+    document.activeElement &&
+    document.activeElement.matches(selector) &&
+    isValidInput(document.activeElement as HTMLInputElement)
+  ) {
+    input = document.activeElement as HTMLInputElement;
+  } else {
+    input = Array.from<HTMLInputElement>(
+      document.querySelectorAll(selector)
+    ).find(isValidInput);
   }
 
-  const activeInputBox =
-    document.activeElement && document.activeElement.tagName === "INPUT"
-      ? document.activeElement
-      : null;
-  if (activeInputBox) {
-    const inputBox = activeInputBox as HTMLInputElement;
-    if (!inputBox.value || /^(\d{6}|\d{8})$/.test(inputBox.value)) {
-      inputBox.value = code;
-      fireInputEvents(inputBox);
-    }
-    return;
+  if (input) {
+    input.value = code;
+    fireInputEvents(input);
   }
-
-  for (const inputBox of inputBoxes) {
-    if (
-      (!inputBox.value || /^(\d{6}|\d{8})$/.test(inputBox.value)) &&
-      inputBox.type !== "password"
-    ) {
-      inputBox.value = code;
-      fireInputEvents(inputBox);
-      return;
-    }
-  }
-  return;
 }
 
 function fireInputEvents(inputBox: HTMLInputElement) {


### PR DESCRIPTION
Instead of checking for specific keywords in the `name` or `id` attributes of HTML input elements, we only need to find the first visible input element with correct `type` attributes and with no value or OTP-code-like values.

I think it's really unstable to check for the appearance of an arbitrary list of keywords in the `name` or `id` attributes, since website maintainers could use anything and it's never going to be exhaustive to match them all. Not to mention the current implementation could really match any hidden inputs that has these keywords in their `name` or `id`. What I think a better way is to find the first visible input element on the page that also has the correct `type` attribute, because it's usually the case that the website will present a single page which includes a single visible input element to the user when asking for their OTP codes.

Also, the new implementation always checks for the active element first and if it's a valid input element it will be used directly. I think this was the intention of the original implementation but I've encountered websites (e.g. Steam) that had hidden input elements that will be matched in the first stage and the function will simply return early.

I also use a single CSS selector to get all input elements with valid `type` attributes, instead of using a loop and an intermediate array to populate them.

I've tested the new implementation on Steam (which the old implementation doesn't work) and other websites and can confirm that it's working fine. However, please do keep in mind that this is a completely different heuristic than the original one so it might break on certain websites, but I think we can improve this on future user reports.