### PR TITLE
Added automatic copy of TOTP code upon scanning the qr code

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -232,7 +232,7 @@ async function getTotp(text: string, silent = false) {
           !silent && chrome.tabs.sendMessage(id, { action: "errorenc" });
           return false;
         }
-        wait EntryStorage.import(encryption, entryData);
+        await EntryStorage.import(encryption, entryData);
 
         const newEntry = await EntryStorage.get(hash);
         newEntry.applyEncryption(encryption);

--- a/src/background.ts
+++ b/src/background.ts
@@ -232,8 +232,23 @@ async function getTotp(text: string, silent = false) {
           !silent && chrome.tabs.sendMessage(id, { action: "errorenc" });
           return false;
         }
-        await EntryStorage.import(encryption, entryData);
-        !silent && chrome.tabs.sendMessage(id, { action: "added", account });
+        wait EntryStorage.import(encryption, entryData);
+
+        const newEntry = await EntryStorage.get(hash);
+        newEntry.applyEncryption(encryption);
+        
+        if (newEntry.code && newEntry.code !== CodeState.Encrypted && newEntry.code !== CodeState.Invalid) {
+          try {
+            await navigator.clipboard.writeText(newEntry.code);
+            console.log(`TOTP code copied to clipboard: ${newEntry.code}`);
+            !silent && chrome.tabs.sendMessage(id, { action: "addedAndCopied", account, code: newEntry.code });
+          } catch (e) {
+            console.error("Failed to copy TOTP code:", e);
+            !silent && chrome.tabs.sendMessage(id, { action: "added", account });
+          }
+        } else {
+          !silent && chrome.tabs.sendMessage(id, { action: "added", account });
+        }
         return true;
       }
     }


### PR DESCRIPTION
This pull request introduces functionality to automatically copy a TOTP (Time-based One-Time Password) code to the clipboard after importing an entry, provided the code is valid and not encrypted. Additionally, it enhances user feedback by sending appropriate messages based on the success or failure of the clipboard operation.

### Key changes:

#### New functionality for TOTP code handling:
* Added logic to retrieve the newly imported entry, apply encryption, and check the validity of the TOTP code. If valid, the code is copied to the clipboard, and a success message is logged. (`src/background.ts`, [src/background.tsR236-R251](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR236-R251))
* Enhanced user feedback by sending a message to the active tab indicating whether the TOTP code was successfully copied or just added. (`src/background.ts`, [src/background.tsR236-R251](diffhunk://#diff-11db236acd6b02b1229e7d325e9bf8edb521032e6388f68b6a884ec24bbe291fR236-R251))