### PR TITLE
fix(storage): parse enums properly

### DIFF
--- a/src/models/storage.ts
+++ b/src/models/storage.ts
@@ -489,7 +489,9 @@ export class EntryStorage {
         counter: data[hash].counter || 0,
         period: data[hash].period || 30,
         digits: data[hash].digits || 6,
-        algorithm: OTPAlgorithm[rawAlgorithm] || OTPAlgorithm.SHA1,
+        algorithm: rawAlgorithm
+          ? OTPAlgorithm[rawAlgorithm]
+          : OTPAlgorithm.SHA1,
         pinned: data[hash].pinned || false,
         hash: data[hash].hash || hash,
       };

--- a/src/models/storage.ts
+++ b/src/models/storage.ts
@@ -487,9 +487,7 @@ export class EntryStorage {
         counter: data[hash].counter || 0,
         period: data[hash].period || 30,
         digits: data[hash].digits || 6,
-        algorithm: rawAlgorithm
-          ? (parseInt(rawAlgorithm) as OTPAlgorithm)
-          : OTPAlgorithm.SHA1,
+        algorithm: OTPAlgorithm[rawAlgorithm] || OTPAlgorithm.SHA1,
         pinned: data[hash].pinned || false,
         hash: data[hash].hash || hash,
       };

--- a/src/models/storage.ts
+++ b/src/models/storage.ts
@@ -463,7 +463,9 @@ export class EntryStorage {
         continue;
       }
 
+      const rawType = data[hash].type;
       const rawAlgorithm = data[hash].algorithm;
+
       const entryData: {
         account: string;
         encrypted: false;
@@ -478,7 +480,7 @@ export class EntryStorage {
         algorithm: OTPAlgorithm;
         pinned: boolean;
       } = {
-        type: (parseInt(data[hash].type) as OTPType) || OTPType[OTPType.totp],
+        type: OTPType[rawType] || OTPType[OTPType.totp],
         index: data[hash].index || 0,
         issuer: data[hash].issuer || "",
         account: data[hash].account || "",


### PR DESCRIPTION
Fix incorrect parsing of the OTP algorithm introduced in version 8.0.0 to enable [this feature](https://github.com/Authenticator-Extension/Authenticator/issues/704).

[The code before (in v7.0.0)](https://github.com/Authenticator-Extension/Authenticator/blob/v7.0.0/src/models/storage.ts#L383-L384):
https://github.com/Authenticator-Extension/Authenticator/blob/bf630cc239e021ad23af88df1e01c06d5ae899bc/src/models/storage.ts#L383-L384

[The code after (in v8.0.0)](https://github.com/Authenticator-Extension/Authenticator/blob/v8.0.0/src/models/storage.ts#L490-L492):
https://github.com/Authenticator-Extension/Authenticator/blob/2cf9b0ff3014bf5db88a3e834e7a2c2c54c96410/src/models/storage.ts#L490-L492

@mymindstorm parsed the algorithm-friendly name (`SHA***`) as an integer instead of casting the enum directly. This resulted in a `NaN`, which would be stripped during serialization.

Since `SHA1` is now considered insecure, companies are likely using `SHA256`, which cannot be parsed and defaults to `SHA1`.

I wasn't sure if keeping `undefined` was what you wanted. Revert https://github.com/Authenticator-Extension/Authenticator/pull/1451/commits/1fc616bad4d99f19ce9708d35c1e3563f583db36 if you think it's better to always use `SHA1` as the default.

It's the same parsing mistake for the `type`, but this one "worked" because the fallback was `OTPType.totp` (the most commonly used).

---

All of the following issues will likely be fixed by this pull request.

Fixes #1442
Fixes #1443
Fixes #1449 
Fixes #1450