### PR TITLE
feat: allow editing HOTP counter in entry edit UI (#1517)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -201,6 +201,10 @@
     "message": "Counter Based",
     "description": "Counter Based"
   },
+  "counter": {
+    "message": "Counter",
+    "description": "HOTP counter value"
+  },
   "resize_popup_page": {
     "message": "Preferences",
     "description": "Popup Page Settings"

--- a/src/components/Popup/EntryComponent.vue
+++ b/src/components/Popup/EntryComponent.vue
@@ -70,6 +70,18 @@
       />
     </div>
     <div
+      class="issuerEdit"
+      v-if="entry.type === OTPType.hotp || entry.type === OTPType.hhex"
+    >
+      <input
+        type="number"
+        min="0"
+        v-model.number="entry.counter"
+        v-bind:placeholder="i18n.counter"
+        v-on:change="onCounterChange(entry)"
+      />
+    </div>
+    <div
       class="showqr"
       v-if="shouldShowQrIcon(entry)"
       v-on:click.stop="showQr(entry)"
@@ -193,6 +205,10 @@ export default Vue.extend({
         this.$store.commit("style/toggleHotpDisabled");
       }, 3000);
       return;
+    },
+    onCounterChange(entry: OTPEntry) {
+      entry.generate();
+      entry.update();
     },
     async copyCode(entry: OTPEntry) {
       if (


### PR DESCRIPTION
Lets users set or correct the HOTP counter when editing an entry, so it can match the value from another app after migration.

- In edit mode, counter-based (HOTP) entries show an editable "Counter" field.
- Changing it updates the displayed code and persists the value.

Closes #1517 (discussion).