### PR TITLE
fix: ensure QR scan overlay receives pointer events on modal pages

### DIFF
--- a/sass/content.scss
+++ b/sass/content.scss
@@ -6,6 +6,7 @@
   height: 100%;
   background: rgba(255, 255, 255, 0.6);
   z-index: 2147483647;
+  pointer-events: auto !important;
   display: none;
   cursor: crosshair;
 }


### PR DESCRIPTION
## Problem

Fixes #1426

The QR code scan overlay (`#__ga_grayLayout__`) does not respond to mouse events (drag-selection is impossible) when the target page has a modal dialog open.

This occurs because some UI frameworks set `pointer-events: none` on `document.body` while a modal is active. For example:

- **Chakra UI v3** (via `@ark-ui/react` → `@zag-js/dismissable`) calls `disablePointerEventsOutside()` which sets `document.body.style.pointerEvents = "none"` and only allows `pointer-events: auto` on the dialog content element.

Since `#__ga_grayLayout__` is appended as a direct child of `document.body`, it inherits `pointer-events: none` through CSS inheritance, making the overlay completely non-interactive — even though it is visually rendered on top via `z-index: 2147483647`.

## Fix

Add `pointer-events: auto !important` to `#__ga_grayLayout__` in `sass/content.scss`. This ensures the overlay always receives pointer events regardless of any inherited styles from the host page.

The `!important` is necessary because the host page sets the style directly on `document.body` via JavaScript (`element.style.pointerEvents = "none"`), which has high specificity.

## Testing

- Built with `npm run chrome` — compiles successfully
- Tested on a page using Chakra UI v3 modal dialog with QR code — scan overlay now appears and drag-selection works correctly
- No regression on pages without modals