### PR TITLE
Fix: normalize Base32 secret from QR import before TOTP generation

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -203,6 +203,9 @@ async function getTotp(text: string, silent = false) {
         ) {
           type = "hhex";
         }
+        if (secret.length % 8) {
+          secret += "=".repeat(8 - (secret.length % 8));
+        }
         const entryData: { [hash: string]: RawOTPStorage } = {};
         entryData[hash] = {
           account,

--- a/src/import.ts
+++ b/src/import.ts
@@ -292,7 +292,10 @@ export async function getEntryDataFromOTPAuthPerLine(importCode: string) {
         ) {
           type = "hhex";
         }
-
+        if (secret.length % 8) {
+          secret += "=".repeat(8 - (secret.length % 8));
+        }
+        
         exportData[hash] = {
           account,
           hash,


### PR DESCRIPTION
Fixes #1546 

A simple fix that adds missing padding when scanning QR Codes that aren't correctly padded.

We are adding padding to make the secret be mod 8 and correctly generate codes similar to other authenticators (Google, Microsoft, Authy, ect.)


Any secrets that match mod 8 won't be affected.