### PR TITLE
perf: cut the popup's serialized storage round trips on cold start

### DIFF
--- a/src/models/settings.ts
+++ b/src/models/settings.ts
@@ -56,8 +56,51 @@ const LocalUserSettingsDataKeys = [
 export class UserSettings {
   static items: UserSettingsData = {};
 
+  // Settings are read from chrome.storage on nearly every storage operation
+  // (see BrowserStorage.getStorageLocation). Reading them afresh each time
+  // costs one or two IPC round trips per call, which adds up to dozens of
+  // serialized round trips before the popup can render. Cache the result and
+  // drop the cache whenever anything writes to storage, so callers still
+  // observe changes made by other extension contexts.
+  private static cachedItems: UserSettingsData | null = null;
+  private static pendingRead: Promise<UserSettingsData> | null = null;
+  private static invalidationHooked = false;
+
+  private static hookInvalidation() {
+    if (UserSettings.invalidationHooked) {
+      return;
+    }
+    UserSettings.invalidationHooked = true;
+    chrome.storage.onChanged?.addListener(() => {
+      UserSettings.invalidateCache();
+    });
+  }
+
+  static invalidateCache() {
+    UserSettings.cachedItems = null;
+  }
+
   static async updateItems() {
-    UserSettings.items = await UserSettings.getAllItems();
+    UserSettings.hookInvalidation();
+
+    if (UserSettings.cachedItems) {
+      UserSettings.items = UserSettings.cachedItems;
+      return;
+    }
+
+    // Coalesce concurrent readers onto a single read.
+    if (!UserSettings.pendingRead) {
+      UserSettings.pendingRead = UserSettings.getAllItems()
+        .then((items) => {
+          UserSettings.cachedItems = items;
+          return items;
+        })
+        .finally(() => {
+          UserSettings.pendingRead = null;
+        });
+    }
+
+    UserSettings.items = await UserSettings.pendingRead;
   }
 
   static async convertFromLocalStorage(
@@ -108,6 +151,7 @@ export class UserSettings {
       ]);
     }
 
+    UserSettings.invalidateCache();
     await UserSettings.updateItems();
   }
 

--- a/src/models/storage.ts
+++ b/src/models/storage.ts
@@ -3,7 +3,23 @@ import { OTPEntry, OTPType, OTPAlgorithm, CodeState } from "./otp";
 import { StorageLocation, UserSettings } from "./settings";
 import { DataType } from "./otp";
 export class BrowserStorage {
-  private static async getStorageLocation(): Promise<StorageLocation> {
+  private static pendingLocation: Promise<StorageLocation> | null = null;
+
+  // Every storage operation resolves the storage location first. Share one
+  // resolution between concurrent callers so parallel readers don't each
+  // re-run the auto-detection branch (which can also commit settings).
+  private static getStorageLocation(): Promise<StorageLocation> {
+    if (!BrowserStorage.pendingLocation) {
+      BrowserStorage.pendingLocation = BrowserStorage.resolveStorageLocation().finally(
+        () => {
+          BrowserStorage.pendingLocation = null;
+        }
+      );
+    }
+    return BrowserStorage.pendingLocation;
+  }
+
+  private static async resolveStorageLocation(): Promise<StorageLocation> {
     await UserSettings.updateItems();
     const managedLocation = await ManagedStorage.get<StorageLocation>(
       "storageArea"
@@ -688,34 +704,82 @@ export class EntryStorage {
 }
 
 export class ManagedStorage {
+  // The managed policy is a single object, but callers read it one key at a
+  // time (the menu store alone reads eight). Fetch it once and answer
+  // subsequent lookups from memory, dropping the cache if policy changes.
+  private static cachedPolicy: ManagedPolicy | null = null;
+  private static pendingPolicy: Promise<ManagedPolicy> | null = null;
+  private static invalidationHooked = false;
+
+  private static hookInvalidation() {
+    if (ManagedStorage.invalidationHooked) {
+      return;
+    }
+    ManagedStorage.invalidationHooked = true;
+    chrome.storage.onChanged?.addListener((_changes, areaName) => {
+      if (areaName === "managed") {
+        ManagedStorage.cachedPolicy = null;
+        ManagedStorage.pendingPolicy = null;
+      }
+    });
+  }
+
+  private static readPolicy(): Promise<ManagedPolicy> {
+    return new Promise((resolve: (result: ManagedPolicy) => void) => {
+      if (chrome.storage.managed) {
+        chrome.storage.managed.get((data) => {
+          if (chrome.runtime.lastError) {
+            return resolve({});
+          }
+          return resolve(data || {});
+        });
+      } else {
+        // no available in Safari
+        resolve({});
+      }
+    });
+  }
+
+  // Share a single underlying read between all callers. The read is kept
+  // running even if an individual lookup times out below, so a policy that
+  // arrives late still populates the cache for subsequent lookups.
+  private static getPolicy(): Promise<ManagedPolicy> {
+    if (!ManagedStorage.pendingPolicy) {
+      ManagedStorage.pendingPolicy = ManagedStorage.readPolicy().then(
+        (data) => {
+          ManagedStorage.cachedPolicy = data;
+          return data;
+        }
+      );
+    }
+    return ManagedStorage.pendingPolicy;
+  }
+
   static get<T>(key: string): T | undefined;
   static get<T>(key: string, defaultValue: T): T;
   static get<T>(key: string, defaultValue?: T) {
-    const managedStoragePromise = new Promise(
-      (resolve: (result: T | undefined) => void) => {
-        if (chrome.storage.managed) {
-          chrome.storage.managed.get((data) => {
-            if (chrome.runtime.lastError) {
-              return resolve(defaultValue);
-            }
-            if (data) {
-              if (data[key]) {
-                return resolve(data[key]);
-              }
-            }
-            return resolve(defaultValue);
-          });
-        } else {
-          // no available in Safari
-          resolve(defaultValue);
-        }
+    ManagedStorage.hookInvalidation();
+
+    const pick = (data: ManagedPolicy) =>
+      data && data[key] ? (data[key] as T) : defaultValue;
+
+    if (ManagedStorage.cachedPolicy) {
+      return Promise.resolve(pick(ManagedStorage.cachedPolicy));
+    }
+
+    // Preserve the original contract: never make a caller wait more than
+    // ~10ms on managed storage.
+    const timeoutPromise = new Promise(
+      (resolve: (r: T | undefined) => void) => {
+        setTimeout(() => resolve(defaultValue), 10);
       }
     );
 
-    const timeoutPromise = new Promise((resolve) => {
-      setTimeout(() => resolve(defaultValue), 10);
-    });
-
-    return Promise.race([managedStoragePromise, timeoutPromise]);
+    return Promise.race([
+      ManagedStorage.getPolicy().then(pick),
+      timeoutPromise,
+    ]);
   }
 }
+
+type ManagedPolicy = Record<string, unknown>;

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -34,9 +34,6 @@ async function init() {
   await migrateLocalStorageToBrowserStorage();
   await UserSettings.updateItems();
 
-  // Add globals
-  Vue.prototype.i18n = await loadI18nMessages();
-
   // Load modules
   Vue.use(Vuex);
   Vue.use(Vue2Dragula);
@@ -46,14 +43,27 @@ async function init() {
     Vue.component(component.name, component.component);
   }
 
+  // The i18n catalog and the async store modules don't depend on one another,
+  // so resolve them concurrently instead of awaiting each in turn.
+  const [i18nMessages, accounts, advisor, backup, menu] = await Promise.all([
+    loadI18nMessages(),
+    new Accounts().getModule(),
+    new Advisor().getModule(),
+    new Backup().getModule(),
+    new Menu().getModule(),
+  ]);
+
+  // Add globals
+  Vue.prototype.i18n = i18nMessages;
+
   // State
   const store = new Vuex.Store({
     modules: {
-      accounts: await new Accounts().getModule(),
-      advisor: await new Advisor().getModule(),
-      backup: await new Backup().getModule(),
+      accounts,
+      advisor,
+      backup,
       currentView: new CurrentView().getModule(),
-      menu: await new Menu().getModule(),
+      menu,
       notification: new Notification().getModule(),
       qr: new Qr().getModule(),
       style: new Style().getModule(),

--- a/src/store/Advisor.ts
+++ b/src/store/Advisor.ts
@@ -100,19 +100,19 @@ export class Advisor implements Module {
         ? JSON.parse(UserSettings.items.advisorIgnoreList || "[]")
         : UserSettings.items.advisorIgnoreList || [];
 
-    const filteredInsightsData: AdvisorInsightInterface[] = [];
+    // The validations are independent reads, so run them concurrently instead
+    // of paying for each one in turn. Order is preserved by index.
+    const candidates = insightsData.filter(
+      (insightData) => !advisorIgnoreList.includes(insightData.id)
+    );
 
-    for (const insightData of insightsData) {
-      if (advisorIgnoreList.includes(insightData.id)) {
-        continue;
-      }
+    const validations = await Promise.all(
+      candidates.map((insightData) => insightData.validation())
+    );
 
-      const validation = await insightData.validation();
-
-      if (validation) {
-        filteredInsightsData.push(insightData);
-      }
-    }
+    const filteredInsightsData: AdvisorInsightInterface[] = candidates.filter(
+      (_, index) => validations[index]
+    );
 
     return filteredInsightsData.map(
       (insightData) => new AdvisorInsight(insightData)

--- a/src/store/Backup.ts
+++ b/src/store/Backup.ts
@@ -2,7 +2,7 @@ import { UserSettings } from "../models/settings";
 
 export class Backup implements Module {
   async getModule() {
-    UserSettings.updateItems();
+    await UserSettings.updateItems();
 
     return {
       state: {


### PR DESCRIPTION
# perf: cut the popup's serialized storage round trips on cold start

## Problem

Opening the popup runs roughly **fifty `chrome.storage` round trips, one after
another**, before Vue can mount. This is the bulk of the perceived "slow to
open" time, and it happens even with a couple of entries and no encryption
configured — so it isn't decryption or data volume.

Two sources account for nearly all of them:

**1. `BrowserStorage.getStorageLocation()`** runs at the top of *every* storage
operation, and each call did:

```ts
await UserSettings.updateItems();                       // 1-2 round trips
const managedLocation = await ManagedStorage.get(...);  // 1 round trip
```

Nothing was cached, so the same values were re-fetched over and over. When
settings live in sync storage, `updateItems()` costs two reads (local + sync)
rather than one.

**2. Everything was awaited in sequence.** `popup.ts` awaited each async Vuex
module in turn, and `Advisor` awaited its five insight validations in turn —
with each validation calling `UserSettings.updateItems()` again from scratch,
and two of them additionally calling `hasEncryptionKey()`.

Approximate breakdown of the round trips before mount:

| Step | Round trips |
|---|---:|
| initial `UserSettings.updateItems()` | 2 |
| `Accounts.getModule()` | 17 |
| `Advisor.getModule()` | 18 |
| `Backup.getModule()` | 2 |
| `Menu.getModule()` (8x `ManagedStorage.get`) | 10 |

## Changes

- **Cache user settings** with invalidation on `chrome.storage.onChanged`, so
  writes from other extension contexts (background, options page) are still
  observed. `commitItems()` invalidates explicitly so it never serves a stale
  read back to its own caller.
- **Cache the managed policy.** It is a single object, but callers read it one
  key at a time — the menu store alone reads eight. It is now fetched once.
- **Coalesce concurrent readers** onto a single in-flight read, in both of the
  above and in `getStorageLocation()`, so parallel callers don't each re-run
  the auto-detection branch (which can also commit settings).
- **Build the store modules and the i18n catalog concurrently** in `popup.ts`.
- **Run the advisor validations concurrently**, preserving output order.
- **Add a missing `await`** in `Backup.getModule()`, which read
  `UserSettings.items` before the read it depends on had resolved.

`ManagedStorage` keeps its original contract: no caller waits more than ~10ms
on managed storage, and a policy that arrives after the timeout still lands in
the cache for later lookups.

## Verification

- `tsc --noEmit` clean; `npm run chrome` builds successfully.
- Measured with a `chrome.storage` mock that counts `get` calls:

| | before | after |
|---|---:|---:|
| 15x `UserSettings.updateItems()` | 30 gets | **2** |
| 8x `ManagedStorage.get()` | 8 gets | **1** |

  Cache invalidation and concurrent reads were checked in the same harness: a
  write followed by a read returns the fresh value, and four concurrent readers
  all resolve correctly.

- The Puppeteer e2e suite could not run in my environment: Chrome 137+ removed
  the `--load-extension` command-line switch the runner depends on, so
  `test-runner.js` fails with `ERR_BLOCKED_BY_CLIENT` on **`dev` as well as on
  this branch** — the failure is pre-existing and unrelated to these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
